### PR TITLE
Fjern "Forskudd på dagpenger"-lenke fra relatert innhold

### DIFF
--- a/src/components/relatertInnhold/RelatertInnhold.tsx
+++ b/src/components/relatertInnhold/RelatertInnhold.tsx
@@ -1,7 +1,6 @@
 import { Heading, Link } from "@navikt/ds-react";
 import { logEvent } from "@src/utils/client/analytics";
 import {
-  dagpengerUrl,
   endreKontonummerUrl,
   endreSkattekortUrl,
   frivilligSkattetrekkUrl,
@@ -40,10 +39,6 @@ const relatertInnholdLinks = [
   {
     title: "Frivillig skattetrekk",
     href: frivilligSkattetrekkUrl,
-  },
-  {
-    title: "Forskudd på dagpenger",
-    href: dagpengerUrl,
   },
 ];
 

--- a/src/utils/client/urls.ts
+++ b/src/utils/client/urls.ts
@@ -84,13 +84,6 @@ const SOSIALHJELP_URL = {
   production: "https://www.nav.no/sosialhjelp/innsyn/utbetaling",
 };
 
-const DAGPENGER_URL = {
-  local: "https://www.nav.no/dagpenger/forskudd/oversikt",
-  ansatt: "https://www.intern.dev.nav.no/dagpenger/forskudd/oversikt",
-  development: "https://www.intern.dev.nav.no/dagpenger/forskudd/oversikt",
-  production: "https://www.nav.no/dagpenger/forskudd/oversikt",
-};
-
 const ÅRSOPPGAVER_URL = {
   local: "https://www.nav.no/dokumentarkiv/tema/STO",
   ansatt: "https://intern.dev.nav.no/dokumentarkiv/tema/STO",
@@ -141,7 +134,6 @@ export const utbetalingsdatoerUrl = UTBETALINGSDATOER_URL[getEnvironment()];
 export const endreKontonummerUrl = ENDRE_KONTONUMMER_URL[getEnvironment()];
 export const endreSkattekortUrl = ENDRE_SKATTEKORT_URL[getEnvironment()];
 export const sosialhjelpUrl = SOSIALHJELP_URL[getEnvironment()];
-export const dagpengerUrl = DAGPENGER_URL[getEnvironment()];
 export const årsoppgaverUrl = ÅRSOPPGAVER_URL[getEnvironment()];
 export const minSideUrl = MIN_SIDE_URL[getEnvironment()];
 export const omUtbetalinger = OM_UTBETALINGER_URL[getEnvironment()];


### PR DESCRIPTION
## Sammendrag
- Fjerner "Forskudd på dagpenger"-lenken fra `RelatertInnhold`-listen.
- Rydder opp den nå ubrukte `DAGPENGER_URL`-konstanten og `dagpengerUrl`-eksporten i `src/utils/client/urls.ts`.

## Test plan
- [x] Åpne utbetalingsoversikt-siden og verifiser at "Forskudd på dagpenger" ikke lenger vises under "Relatert innhold".
- [x] Verifiser at øvrige lenker i "Relatert innhold" fortsatt fungerer som før.