### PR TITLE
Enable Vite build sourcemaps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,11 @@ export default defineConfig({
     assetsPrefix:
       "https://cdn.nav.no/min-side/tms-utbetalingsoversikt-frontend",
   },
+  vite: {
+    build: {
+      sourcemap: true,
+    },
+  },
   integrations: [react()],
   logger: {
     entrypoint: "@navikt/astro-logger",


### PR DESCRIPTION
Adds `vite.build.sourcemap: true` to the Astro config so that production builds emit source maps alongside bundled assets. This makes it possible to trace minified stack traces back to original source lines when debugging runtime errors in production.