### PR TITLE
Add Digestabot workflow

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,24 @@
+name: "Check for newer image versions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every monday at 08:00.
+    - cron: "0 8 * * 1"
+
+jobs:
+  digest-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: navikt/digestabot@3302a753e533ceb9ec216de7f78345436cd636e3 # v1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          team: min-side


### PR DESCRIPTION
Adds automated checks for newer container image versions so dependency updates can be proposed regularly.

The workflow runs every Monday at 08:00 UTC or on manual dispatch, uses SHA-pinned actions, and grants only the permissions needed to create update pull requests.