### PR TITLE
ci: bruk astro-deploy workflow fra tms-deploy

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,77 +12,10 @@ permissions:
   packages: 'write'
 
 jobs:
-  build:
-    name: 'build'
-    runs-on: 'ubuntu-latest'
+  build-and-deploy:
+    uses: 'navikt/tms-deploy/.github/workflows/astro-deploy-v1.yaml@main'
+    with:
+      app-name: 'tms-utbetalingsoversikt-frontend'
+      clusters: '["dev-gcp"]'
+    secrets: 'inherit'
 
-    steps:
-      - uses: 'actions/checkout@v4'
-      - uses: 'pnpm/action-setup@v4'
-        with:
-          version: 10
-          run_install: false
-      - uses: 'actions/setup-node@v4'
-        with:
-          node-version: 24
-          registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
-
-      - name: 'Install dependencies'
-        run: 'pnpm install --config.minimum-release-age=10080 --frozen-lockfile'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: 'Run unit tests'
-        run: 'pnpm run test'
-        env:
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Install Playwright browsers'
-        run: 'pnpm exec playwright install --with-deps chromium'
-
-      - name: 'Run E2E tests'
-        run: 'pnpm run test:e2e'
-        env:
-          CI: 'true'
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Build application'
-        run: 'pnpm run build'
-        env:
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Upload to cdn'
-        uses: nais/deploy/actions/cdn-upload/v2@master
-        with:
-          team: min-side
-          source: ./dist/client/_astro
-          destination: 'tms-utbetalingsoversikt-frontend'
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-
-      - name: 'Build and push'
-        uses: nais/docker-build-push@v0
-        id: docker-build-push
-        with:
-          team: min-side
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  deploy-dev:
-    runs-on: 'ubuntu-latest'
-    needs: 'build'
-    strategy:
-      matrix:
-        cluster: [dev-gcp]
-    steps:
-      - uses: 'actions/checkout@v4'
-      - name: 'Deploy to dev'
-        uses: 'nais/deploy/actions/deploy@v2'
-        env:
-          CLUSTER: ${{ matrix.cluster }}
-          RESOURCE: nais/${{ matrix.cluster }}/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -10,77 +10,10 @@ permissions:
   packages: 'write'
 
 jobs:
-  build:
-    name: 'build'
-    runs-on: 'ubuntu-latest'
+  build-and-deploy:
+    uses: 'navikt/tms-deploy/.github/workflows/astro-deploy-v1.yaml@main'
+    with:
+      app-name: 'tms-utbetalingsoversikt-frontend'
+      clusters: '["dev-gcp", "prod-gcp"]'
+    secrets: 'inherit'
 
-    steps:
-      - uses: 'actions/checkout@v3'
-      - uses: 'pnpm/action-setup@v4'
-        with:
-          version: 10
-          run_install: false
-      - uses: 'actions/setup-node@v3'
-        with:
-          node-version: 24
-          registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
-
-      - name: 'Install dependencies'
-        run: 'pnpm install --config.minimum-release-age=10080 --frozen-lockfile'
-        env:
-            NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: 'Run unit tests'
-        run: 'pnpm run test'
-        env:
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Install Playwright browsers'
-        run: 'pnpm exec playwright install --with-deps chromium'
-
-      - name: 'Run E2E tests'
-        run: 'pnpm run test:e2e'
-        env:
-          CI: 'true'
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Build application'
-        run: 'pnpm run build'
-        env:
-          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
-
-      - name: 'Upload to cdn'
-        uses: nais/deploy/actions/cdn-upload/v2@master
-        with:
-          team: min-side
-          source: ./dist/client/_astro
-          destination: 'tms-utbetalingsoversikt-frontend'
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-
-      - name: 'Build and push'
-        uses: nais/docker-build-push@v0
-        id: docker-build-push
-        with:
-          team: min-side
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  deploy:
-    runs-on: 'ubuntu-latest'
-    needs: 'build'
-    strategy:
-      matrix:
-        cluster: [dev-gcp, prod-gcp]
-    steps:
-      - uses: 'actions/checkout@v3'
-      - name: 'Deploy'
-        uses: 'nais/deploy/actions/deploy@v2'
-        env:
-          CLUSTER: ${{ matrix.cluster }}
-          RESOURCE: nais/${{ matrix.cluster }}/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}


### PR DESCRIPTION
Erstatter inline build/deploy-steg i `deploy-dev.yaml` og `deploy-main.yaml` med den delte gjenbrukbare workflowen `navikt/tms-deploy/.github/workflows/astro-deploy-v1.yaml@main`, på samme måte som i tms-utkast-frontend.

Den delte workflowen kjører samme steg som før: pnpm install (minimum-release-age 10080), enhetstester, Playwright E2E, build, CDN-opplasting av `./dist/client/_astro`, docker-build-push og nais deploy.

- **deploy-dev**: `workflow_dispatch` + push til `dev-*`/`sasoria-*` → `dev-gcp`
- **deploy-main**: push til `main` → `dev-gcp` + `prod-gcp`

Krever samme secrets/vars som før (`READER_TOKEN`, `ASTRO_KEY`, `NAIS_WORKLOAD_IDENTITY_PROVIDER`, `NAIS_MANAGEMENT_PROJECT_ID`) via `secrets: inherit`.