### PR TITLE
Add tms-copilot customization sync

### DIFF
--- a/.github/workflows/tms-copilot-sync.yaml
+++ b/.github/workflows/tms-copilot-sync.yaml
@@ -1,0 +1,13 @@
+name: Tms-copilot Customization Sync
+on:
+  schedule:
+    - cron: '0 7 * * 1'  # Mandager kl 07:00
+  workflow_dispatch:
+jobs:
+  sync:
+    uses: navikt/tms-copilot/.github/workflows/tms-copilot-sync.yml@main
+    with:
+      source_repo: navikt/tms-copilot
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Adds the TMS-specific Copilot customization sync so this app receives shared configuration from `navikt/tms-copilot`, matching the setup in `tms-utkast-frontend`.

The workflow runs every Monday at 07:00 and can also be triggered manually. The existing general Copilot sync remains unchanged.