### PR TITLE
docs(readme): dokumenter app og integrasjoner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Frontend for utbetalingsoversikten på innloggede sider på nav.no. Her kan pers
 
 Appen er bygget med Astro, React og Aksel. Brukeren autentiseres med ID-porten. Appen bruker TokenX til å hente utbetalingsdetaljer og personens navn fra bakenforliggende tjenester.
 
+## Arkitektur
+
+```mermaid
+flowchart LR
+    bruker["Innbygger\n(nettleser)"]
+    frontend["tms-utbetalingsoversikt-frontend\n(Astro SSR og React)"]
+    backend["tms-utbetalingsoversikt-api"]
+    pdl["pdl-api\n(GraphQL)"]
+
+    bruker -->|ID-porten-innlogging| frontend
+    bruker -->|Utbetalingsoversikt| backend
+    frontend -->|TokenX OBO-token for detaljer| backend
+    frontend -->|TokenX OBO-token for navn| pdl
+```
+
+Oversikten hentes fra `tms-utbetalingsoversikt-api` i nettleseren. Detaljsider rendres på serveren, der brukerens token veksles til et on-behalf-of-token via TokenX før appen kaller utbetalings-API-et og PDL.
+
 ## Miljøer
 
 - [Produksjon](https://www.nav.no/utbetalingsoversikt)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,53 @@
 # tms-utbetalingsoversikt-frontend
 
-Frontend for den innloggede utbetalingsoversikten for eksterne brukere.
+[![Deploy main](https://github.com/navikt/tms-utbetalingsoversikt-frontend/actions/workflows/deploy-main.yaml/badge.svg)](https://github.com/navikt/tms-utbetalingsoversikt-frontend/actions/workflows/deploy-main.yaml)
+[![Astro](https://img.shields.io/badge/Astro-7-BC52EE?logo=astro&logoColor=white)](https://astro.build/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Biome](https://img.shields.io/badge/Biome-2-60A5FA?logo=biome&logoColor=white)](https://biomejs.dev/)
+[![Vitest](https://img.shields.io/badge/Vitest-4-6E9F18?logo=vitest&logoColor=white)](https://vitest.dev/)
 
-# Kom i gang
+## Formål
 
-1. Installer dependencies med `pnpm install`
-2. Bygg appen ved å kjøre `pnpm run build`
-3. Start hono mockserver med `pnpm run mock`
-4. Med mockserver kjørende i egen terminal, start appen lokalt ved å kjøre `pnpm run dev` i et nytt terminalvindu
-5. Appen nås på http://localhost:4321/utbetalingsoversikt
+Frontend for utbetalingsoversikten på innloggede sider på nav.no. Her kan personbrukere:
 
-# Henvendelser
+- se kommende og tidligere utbetalinger
+- filtrere utbetalinger på periode og ytelse
+- åpne detaljer om en utbetaling
+- skrive ut oversikten eller en enkelt utbetaling
 
-Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på github.
+Appen er bygget med Astro, React og Aksel. Brukeren autentiseres med ID-porten. Appen bruker TokenX til å hente utbetalingsdetaljer og personens navn fra bakenforliggende tjenester.
 
-## For NAV-ansatte
+## Miljøer
 
-Interne henvendelser kan sendes via Slack i kanalen [#team-minside](https://nav-it.slack.com/archives/C0912F59V29).
+- [Produksjon](https://www.nav.no/utbetalingsoversikt)
+- [Development](https://www.intern.dev.nav.no/utbetalingsoversikt)
+- [Development for ansatte](https://www.ansatt.dev.nav.no/utbetalingsoversikt)
+
+## Backend-tjenester
+
+### [tms-utbetalingsoversikt-api](https://github.com/navikt/tms-utbetalingsoversikt-api)
+
+Leverer kommende og tidligere utbetalinger samt detaljer om en enkelt utbetaling.
+
+- **GET** `/utbetalinger/alle`
+- **GET** `/utbetalinger/ssr/{id}`
+
+### [pdl-api](https://github.com/navikt/pdl)
+
+Leverer personens navn til utskriftsvisningen via GraphQL.
+
+- **POST** `/graphql`
+
+## Utvikling
+
+Prosjektet krever Node.js 24 eller nyere og bruker pnpm. Kjør `pnpm run` for en oppdatert oversikt over tilgjengelige kommandoer for lokal utvikling, bygging og testing.
+
+Ved lokal utvikling er appen tilgjengelig på [http://localhost:4321/utbetalingsoversikt](http://localhost:4321/utbetalingsoversikt). Astro-integrasjonen `@navikt/astro-mocks` leverer lokale mockdata.
+
+## Henvendelser
+
+Spørsmål om koden eller prosjektet kan opprettes som [issues i GitHub](https://github.com/navikt/tms-utbetalingsoversikt-frontend/issues).
+
+## For Nav-ansatte
+
+Interne henvendelser kan sendes i [#team-minside på Slack](https://nav-it.slack.com/archives/C0912F59V29).


### PR DESCRIPTION
README-en beskrev ikke lenger appens faktiske oppsett og viste foreldede kommandoer for lokal utvikling. Denne endringen gjør inngangen til repoet mer presis for nye utviklere.

## Endringer

- beskriver formålet og de viktigste brukerfunksjonene
- dokumenterer miljøer, ID-porten, TokenX og backend-tjenester
- legger til relevante badges for deploy, stack og verktøy
- erstatter foreldede oppstartskommandoer med `pnpm run` som oppdatert kommandokilde
- bevarer lokal URL og kontaktinformasjon for Team Min side

## Verifisering

Ikke kjørt tester. Endringen gjelder kun dokumentasjon, og innholdet er kryssjekket mot kildekode, `package.json`, NAIS-manifester og deploy-workflows.